### PR TITLE
Removed redundant tree function

### DIFF
--- a/html/js/thirdparty/README.md
+++ b/html/js/thirdparty/README.md
@@ -1,4 +1,3 @@
 This directory contains third party JavaScript libraries:
 
 - SVG.js is a lightweight library for manipulating and animating SVG. It has no dependencies and aims to be as minimal as possible. This folder contains the minimized version of the library and the humanized one. For more information about the library refer to the official GitHub page (SVG.js) [https://github.com/wout/svg.js] and its (documentation) [http://documentup.com/wout/SVG.js]
-

--- a/html/js/tree/Tree.js
+++ b/html/js/tree/Tree.js
@@ -173,20 +173,6 @@ GTE.TREE = (function (parentModule) {
     };
 
     /**
-    * Function that clears the canvas
-    * Takes care of removing the foreigns used during inline editing
-    */
-    Tree.prototype.clear = function(){
-        // Clear canvas
-        GTE.canvas.clear();
-        // Remove labels
-        var foreigns = document.getElementsByTagName("foreignObject");
-        for (var index = foreigns.length - 1; index >= 0; index--) {
-            foreigns[index].parentNode.removeChild(foreigns[index]);
-        }
-    };
-
-    /**
     * Recursive function that draws the Game in the global canvas starting from a node
     * If no param is given it will start from root
     * Stopping criteria: that the current node is a leaf


### PR DESCRIPTION
Tree.js had an additional clear function. This commit removes it.
