### PR TITLE
width increase for settings pane to display all options

### DIFF
--- a/html/css/main.css
+++ b/html/css/main.css
@@ -308,7 +308,7 @@ a {
 
 #settings > div {
     position: relative;
-    width:300px;
+    width: 380px;
     margin: 100px auto;
     background-color: #fff;
     border:1px solid #000;


### PR DESCRIPTION
Width of the settings pane is increased so as to access all the options as can be seen in the screenshot below:
![screenshot from 2016-03-14 20 10 45](https://cloud.githubusercontent.com/assets/8044561/13748112/6e827100-ea21-11e5-8517-f7a978c33b39.png)
Hence, Fix for #63 
