### PR TITLE
payoff accepting number values only

### DIFF
--- a/html/js/tree/Payoff.js
+++ b/html/js/tree/Payoff.js
@@ -76,7 +76,7 @@ GTE.TREE = (function(parentModule) {
         } else {
             window.alert("Payoff should be a number.");
             // In order to get the previous text back, change text to current this.text
-            this.changeText(this.text);
+            this.editable.setText(this.text);
         }
         return this.value;
     };


### PR DESCRIPTION
At present when the payoff value is edited, if we try to set payoff value to be something of the form anything followed by a character eg. j90l, k99 etc. we get a prompt telling that payoff should be a number, but when we click OK, it doesn't really erase the non-numbered value and gets us back the last value i.e. after alert message also, such non-acceptable values of payoffs are visible on the screen. After this patch, if such non-acceptable values are used to set, then payoff value would automatically takes the last acceptable value that it was taking after giving the alert prompt.
