### PR TITLE
no more empty payoff after erasing its value

### DIFF
--- a/html/js/tree/Payoff.js
+++ b/html/js/tree/Payoff.js
@@ -39,9 +39,8 @@ GTE.TREE = (function(parentModule) {
                     var text = this.getCleanedText();
                     if (text === "") {
                         window.alert("Payoff should not be empty.");
-                    } else {
-                        thisPayoff.changeText(text);
                     }
+                    thisPayoff.changeText(text);
                 });
     };
 
@@ -50,6 +49,8 @@ GTE.TREE = (function(parentModule) {
      * @param {String} text New payoff's text
      */
     Payoff.prototype.changeText = function(text) {
+      //Check if it's empty or not
+      if(text !== "") {
         // Remove leading 0
         var value = parseFloat(text, 10);
         // Check if it's a fraction
@@ -78,6 +79,10 @@ GTE.TREE = (function(parentModule) {
             // In order to get the previous text back, change text to current this.text
             this.changeText(this.text);
         }
+      } else {
+        //If it's empty, set its value to the last stored value
+        this.editable.setText(this.text);
+      }
         return this.value;
     };
 


### PR DESCRIPTION
Whenever we try to make the value of Payoffs empty, it shows us the prompt that `payoff should not be empty` but, after clicking OK button, payoff value remains empty. Hence after this patch, last payoff value stored will get displayed after clicking the OK button.
