### PR TITLE
Changed constant variables to storage variables.

### DIFF
--- a/html/js/guiutils/MultiAction.js
+++ b/html/js/guiutils/MultiAction.js
@@ -18,21 +18,21 @@ GTE.TREE = (function(parentModule) {
             }
         }
         this.level = level;
-        this.y = this.level * GTE.CONSTANTS.DIST_BETWEEN_LEVELS +
-            GTE.CONSTANTS.CIRCLE_SIZE / 2;
+        this.y = this.level * GTE.STORAGE.settingsDistLevels +
+            GTE.STORAGE.settingsCircleSize / 2;
     }
 
     MultiAction.prototype.draw = function() {
-        var width = (this.x2 + GTE.CONSTANTS.CIRCLE_SIZE) - this.x1;
+        var width = (this.x2 + parseInt(GTE.STORAGE.settingsCircleSize)) - this.x1;
 
-        this.shape = GTE.canvas.rect(width, GTE.CONSTANTS.CIRCLE_SIZE)
-            .radius(GTE.CONSTANTS.CIRCLE_SIZE / 2)
+        this.shape = GTE.canvas.rect(width, GTE.STORAGE.settingsCircleSize)
+            .radius(GTE.STORAGE.settingsCircleSize / 2)
             .fill({
                 color: '#9d9d9d'
             })
             .addClass('multiaction-rect');
         this.shape.translate(this.x1,
-            this.y - GTE.CONSTANTS.CIRCLE_SIZE / 2);
+            this.y - GTE.STORAGE.settingsCircleSize / 2);
         var thisMultiAction = this;
         this.shape.mouseover(function() {
             thisMultiAction.interaction();


### PR DESCRIPTION
Earlier the geometric values used to render multiaction lines were the default values. Changed to the current value stored in storage variables.
This led to the following problem among many : 
![shot-1](https://cloud.githubusercontent.com/assets/8079861/14058115/99c17496-f33c-11e5-9b35-4fc6f1e50c1d.png)
Now it looks like this 
![shot-2](https://cloud.githubusercontent.com/assets/8079861/14058116/a5f0839c-f33c-11e5-8399-a6273a4f3329.png)

Reason : The default circle radius (20) and distance between levels (150) values were being used earlier.
Changed to the current values as set in the storage variables.
