### PR TITLE
Using move names of first info set while merging--fixes #79

### DIFF
--- a/html/js/tree/Tree.js
+++ b/html/js/tree/Tree.js
@@ -762,14 +762,14 @@ GTE.TREE = (function (parentModule) {
             window.alert("Couldn't merge the information sets." +
             "Please select two information sets that do not share a path from root.");
         }else {
-            // Add Node A to Node B ISet
-            var nodesInA = a.getNodes();
-            for (var i = 0; i < nodesInA.length; i++) {
-                nodesInA[i].changeISet(b);
+            // Add Node B to Node A ISet
+            var nodesInB = b.getNodes();
+            for (var i = 0; i < nodesInB.length; i++) {
+                nodesInB[i].changeISet(a);
             }
         }
         this.positionsUpdated = false;
-        return b;
+        return a;
     };
 
     Tree.prototype.iSetsSharePathFromRoot = function (a, b) {


### PR DESCRIPTION
After this patch, move names of first info set will be used instead of last info set while merging two or more info sets. Fixes #79 
![screenshot from 2016-04-10 13 36 28](https://cloud.githubusercontent.com/assets/8044561/14408842/7d3f6b24-ff22-11e5-9ad9-4342b8dbb23d.png)
