### PR TITLE
ISets mergeable and payoff and movenames displaying after new game

### DIFF
--- a/html/js/guiutils/Tools.js
+++ b/html/js/guiutils/Tools.js
@@ -30,6 +30,8 @@ GTE.UI = (function (parentModule) {
         // Create a node and draw it
         GTE.tree.draw();
         this.switchMode(GTE.MODES.ADD);
+
+        this.isetToolsRan = false;
     };
 
     /**


### PR DESCRIPTION
Now, ISets will be recognized as mergeable and the payoff values and movenames will be displayed for a new game started by the new game button and not by refreshing the page.
Hence, fixes #78 
