### PR TITLE
merging of root with any other node- fixes #46 and #80

### DIFF
--- a/html/js/tree/Tree.js
+++ b/html/js/tree/Tree.js
@@ -758,7 +758,7 @@ GTE.TREE = (function (parentModule) {
         } else if (this.iSetsSharePathFromRoot(a, b)) {
             window.alert("Couldn't merge the information sets." +
             "Please select two information sets that do not share a path from root.");
-        } else if (a.firstNode === this.root && b.firstNode === this.root) {
+        } else if (a.firstNode === this.root || b.firstNode === this.root) {
             window.alert("Couldn't merge the information sets." +
             "Please select two information sets that do not share a path from root.");
         }else {


### PR DESCRIPTION
At present, if we try to merge root of the tree with any other node of the tree, it shows us some weird behavior as discussed in #46 and #80 . After this patch, if we try to merge root with any other node of tree, we will get a warning `Couldn't merge the information sets.Please select two information sets that do not share a path from root`.
Hence fixing #46 and #80 
